### PR TITLE
feature/support-working-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ The volume (-v or --volume=) must mount the directory within which the changelog
 
 The environment variables required are:
 
-POSTGRES_USER - the user to the target database  
-POSTGRES_PASSWORD - password to the target database  
-POSTGRES_DB - the target database name  
-POSTGRES_HOST - the IP address of the target database  
-POSTGRES_PORT - the port postgres is running on
-CHANGELOG_FILE - the name of the changelog file
+`POSTGRES_USER` - the user to the target database
+`POSTGRES_PASSWORD` - password to the target database
+`POSTGRES_DB` - the target database name
+`POSTGRES_HOST` - the IP address of the target database
+`POSTGRES_PORT` - the port postgres is running on
+`CHANGELOG_FILE` - the name of the changelog file (absolute path, unless using `CHANGELOG_PWD`)
 
 and optionally
 
-MAX_TRIES - default which defaults to 4 if not set
+`CHANGELOG_PWD` - sets the PWD for liquibase to run from
+`MAX_TRIES` - default which defaults to 4 if not set

--- a/update.sh
+++ b/update.sh
@@ -4,25 +4,26 @@ echo "Setting up liquidbase"
 : ${POSTGRES_USER?"POSTGRES_USER not set"}
 : ${POSTGRES_PASSWORD?"POSTGRES_PASSWORD not set"}
 
-cat <<CONF > /home/duser/liquibase.properties
-  driver: org.postgresql.Driver
-  classpath:/opt/jdbc_drivers/postgresql-9.3-1102-jdbc41.jar
-  url: jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB
-  username: $POSTGRES_USER
-  password: $POSTGRES_PASSWORD
-CONF
-
 echo "Applying changelogs ..."
 : ${CHANGELOG_FILE:="changelogs.xml"}
+
+if [ -n "$CHANGELOG_PWD" ]; then cd $CHANGELOG_PWD; fi
 
 ERROR_EXIT_CODE=1
 MAX_TRIES=${MAX_TRIES:-4}
 COUNT=1
 while [  $COUNT -le $MAX_TRIES ]; do
    echo  "Attempting to apply changelogs: attempt $COUNT of $MAX_TRIES"
-   liquibase --changeLogFile="/changelogs/$CHANGELOG_FILE" update
-   if [ $? -eq 0 ];then
-   	  echo "Changelogs successfully applied"
+   liquibase \
+      --driver=org.postgresql.Driver \
+      --classpath=/opt/jdbc_drivers/postgresql-9.3-1102-jdbc41.jar \
+      --url="jdbc:postgresql://$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB" \
+      --username="$POSTGRES_USER" \
+      --password="$POSTGRES_PASSWORD" \
+      --changeLogFile="$CHANGELOG_FILE" \
+      update
+    if [ $? -eq 0 ];then
+      echo "Changelogs successfully applied"
       exit 0
    fi
    echo "Failed to apply changelogs"


### PR DESCRIPTION
# problem statement

- some liquibase changelogs use relative paths to include changesets.  these include statements do not always use the liquibase properties for specifying to use relative paths.  instead, they rely on liquibase being run from a specific dir.  the current image does not support running liquibase from a specified dir.

# solution

support a user provided `pwd`!

# testing?

i tested it :), works great
